### PR TITLE
Modify Dockerfile to allow for quicker rebuild times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@
 FROM fnndsc/ubuntu-python3:18.04
 MAINTAINER fnndsc "dev@babymri.org"
 
-RUN mkdir /usr/src/pdfgeneration
 
 ENV APPROOT="/usr/src/pdfgeneration"
+RUN mkdir $APPROOT
 ENV DEBIAN_FRONTEND=noninteractive
 COPY ["requirements.txt", "${APPROOT}"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@
 FROM fnndsc/ubuntu-python3:18.04
 MAINTAINER fnndsc "dev@babymri.org"
 
+RUN mkdir -p /usr/src/pdfgeneration
+
 ENV APPROOT="/usr/src/pdfgeneration"
 ENV DEBIAN_FRONTEND=noninteractive
 COPY ["requirements.txt", "${APPROOT}"]
-
-WORKDIR $APPROOT
 
 RUN apt-get update \
   && apt-get install -y libsm6 libxext6 libxrender-dev wkhtmltopdf xvfb \
@@ -37,6 +37,8 @@ RUN apt-get update \
   && pip install -r requirements.txt
 
 COPY ["pdfgeneration", "${APPROOT}"]
+
+WORKDIR $APPROOT
 
 CMD ["pdfgeneration.py", "--help"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,13 @@
 FROM fnndsc/ubuntu-python3:18.04
 MAINTAINER fnndsc "dev@babymri.org"
 
-RUN mkdir -p /usr/src/pdfgeneration
+RUN mkdir /usr/src/pdfgeneration
 
 ENV APPROOT="/usr/src/pdfgeneration"
 ENV DEBIAN_FRONTEND=noninteractive
 COPY ["requirements.txt", "${APPROOT}"]
+
+WORKDIR $APPROOT
 
 RUN apt-get update \
   && apt-get install -y libsm6 libxext6 libxrender-dev wkhtmltopdf xvfb \
@@ -37,8 +39,6 @@ RUN apt-get update \
   && pip install -r requirements.txt
 
 COPY ["pdfgeneration", "${APPROOT}"]
-
-WORKDIR $APPROOT
 
 CMD ["pdfgeneration.py", "--help"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ MAINTAINER fnndsc "dev@babymri.org"
 
 ENV APPROOT="/usr/src/pdfgeneration"
 ENV DEBIAN_FRONTEND=noninteractive
-COPY ["pdfgeneration", "${APPROOT}"]
 COPY ["requirements.txt", "${APPROOT}"]
 
 WORKDIR $APPROOT
@@ -36,6 +35,8 @@ RUN apt-get update \
   && apt-get install -y libsm6 libxext6 libxrender-dev wkhtmltopdf xvfb \
   && pip install --upgrade pip \
   && pip install -r requirements.txt
+
+COPY ["pdfgeneration", "${APPROOT}"]
 
 CMD ["pdfgeneration.py", "--help"]
 


### PR DESCRIPTION
Moved source code copy to occur as late as possible to rely on less frequently modified docker layers, that stay in cache, which therefore don't need to be rebuilt.